### PR TITLE
Fix: Load `version_path` input in config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ export async function main() {
       version: core.getInput("version"),
       versionUrl: core.getInput("version_url"),
       versionRegex: core.getInput("version_regex"),
+      versionPath: core.getInput("version_path"),
       downloadUrl: core.getInput("download_url"),
       downloadName: core.getInput("download_name"),
       binPath: core.getInput("bin_path"),


### PR DESCRIPTION
Fix that the `version_path` input (defined in `action.yaml` and exists as property `versionPath` in the `Config` type) it not being loaded from the GitHub Actions inputs.